### PR TITLE
Migrate Workflow schema/types

### DIFF
--- a/models/CHANGELOG.md
+++ b/models/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+* Finalize migration from [puppetlabs/relay-core](https://github.com/puppetlabs/relay-core).
+
 ## [1.0.0] - 2021-08-23
 
 ### Added

--- a/models/go.mod
+++ b/models/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/golangci/golangci-lint v1.36.0
 	github.com/puppetlabs/leg/httputil v0.1.4
 	github.com/puppetlabs/leg/stringutil v0.1.0
-	github.com/puppetlabs/relay-core v0.0.0-20210816202946-cdb56ed33218
+	github.com/puppetlabs/relay-core v0.0.0-20210824082855-2dea243b2a1a
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/shurcooL/vfsgen v0.0.0-20200824052919-0d455de96546
 	github.com/stretchr/testify v1.7.0

--- a/models/go.sum
+++ b/models/go.sum
@@ -1132,8 +1132,8 @@ github.com/puppetlabs/leg/stringutil v0.1.0/go.mod h1:xIQbHjzTxuqVz/GpY5ReCqxGWp
 github.com/puppetlabs/leg/timeutil v0.3.0/go.mod h1:FHkZ9rYegF0STjS4az6hsjdvcBHcG+FB4CsY5mx1DfI=
 github.com/puppetlabs/leg/workdir v0.1.0/go.mod h1:wqtQ5F1GvWJ2OH0OaDYkZnF4Iq+yV9uojU6kBub6jcA=
 github.com/puppetlabs/pvpool v0.3.0/go.mod h1:yxvaQJGhcIuzUrpmWnVKG+86JRDK1JR0RepBbImMM+Q=
-github.com/puppetlabs/relay-core v0.0.0-20210816202946-cdb56ed33218 h1:J6UUJZGJeMaIuxSdyRWCtUjhzuEuXMNNTRv2BZHlrN0=
-github.com/puppetlabs/relay-core v0.0.0-20210816202946-cdb56ed33218/go.mod h1:cd9GBBn8EW93gSHaEkCpnPqJ/3uPZq+YWART96YhEXQ=
+github.com/puppetlabs/relay-core v0.0.0-20210824082855-2dea243b2a1a h1:yZt8aqSbnLZSIFqRCpsPSPcavETok+EJirq+KB6yGRo=
+github.com/puppetlabs/relay-core v0.0.0-20210824082855-2dea243b2a1a/go.mod h1:Po/T1Snd3HCHcFQY/uWDir951Yx4cjZxFlAyZmDyG+I=
 github.com/puppetlabs/relay-pls v0.0.0-20201125074651-13575df50b51/go.mod h1:xtYyc7gvvVZtfAn5kM89ihJj6v5zdBjNjMfp+a6z+8o=
 github.com/qri-io/starlib v0.4.2-0.20200213133954-ff2e8cd5ef8d/go.mod h1:7DPO4domFU579Ga6E61sB9VFNaniPVwJP5C4bBCu3wA=
 github.com/quasilyte/go-consistent v0.0.0-20190521200055-c6f3937de18c/go.mod h1:5STLWrekHfjyYwxBRVRXNOSewLJ3PWfDJd1VyTS21fI=

--- a/models/pkg/workflow/types/v1/schema.go
+++ b/models/pkg/workflow/types/v1/schema.go
@@ -1,8 +1,8 @@
 package v1
 
 import (
+	"github.com/puppetlabs/relay-client-go/models/pkg/workflow/asset"
 	"github.com/puppetlabs/relay-core/pkg/util/typeutil"
-	"github.com/puppetlabs/relay-core/pkg/workflow/asset"
 	"github.com/xeipuuv/gojsonschema"
 )
 

--- a/models/pkg/workflow/types/v1/types_test.go
+++ b/models/pkg/workflow/types/v1/types_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	v1 "github.com/puppetlabs/relay-core/pkg/workflow/types/v1"
+	v1 "github.com/puppetlabs/relay-client-go/models/pkg/workflow/types/v1"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v3"
 )

--- a/models/pkg/workflow/types/v1/validate_test.go
+++ b/models/pkg/workflow/types/v1/validate_test.go
@@ -6,8 +6,8 @@ import (
 	"strings"
 	"testing"
 
+	v1 "github.com/puppetlabs/relay-client-go/models/pkg/workflow/types/v1"
 	"github.com/puppetlabs/relay-core/pkg/util/typeutil"
-	v1 "github.com/puppetlabs/relay-core/pkg/workflow/types/v1"
 	"github.com/stretchr/testify/require"
 )
 


### PR DESCRIPTION
- Finalize workflow schema/types migration from [puppetlabs/relay-core](https://github.com/puppetlabs/relay-core).