### PR TITLE
Improve oneOf generation

### DIFF
--- a/client/CHANGELOG.md
+++ b/client/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Fixed
+* Use `--additional-properties useOneOfDiscriminatorLookup=true` for improved `oneOf` handling.
+
 ## [0.4.0] - 2021-08-31
 
 ### Fixed

--- a/client/pkg/client/openapi/generate.go
+++ b/client/pkg/client/openapi/generate.go
@@ -1,3 +1,3 @@
 package openapi
 
-//go:generate 	docker run --rm -v "${PWD}:/local" gcr.io/nebula-contrib/openapi-generator-cli:latest generate -i https://api.relay.sh/openapi/latest -g go --global-property apis,models,supportingFiles,modelDocs=false -o /local/pkg/client/openapi
+//go:generate 	docker run --rm -v "${PWD}:/local" gcr.io/nebula-contrib/openapi-generator-cli:latest generate -i https://api.relay.sh/openapi/latest -g go --global-property apis,models,supportingFiles,modelDocs=false --additional-properties useOneOfDiscriminatorLookup=true -o /local/pkg/client/openapi

--- a/client/pkg/client/openapi/model_token_with_secret.go
+++ b/client/pkg/client/openapi/model_token_with_secret.go
@@ -29,34 +29,38 @@ func UserTokenWithSecretAsTokenWithSecret(v *UserTokenWithSecret) TokenWithSecre
 // Unmarshal JSON data into one of the pointers in the struct
 func (dst *TokenWithSecret) UnmarshalJSON(data []byte) error {
 	var err error
-	match := 0
-	// try to unmarshal data into UserTokenWithSecret
-	err = json.Unmarshal(data, &dst.UserTokenWithSecret)
-	if err == nil {
-		jsonUserTokenWithSecret, err := json.Marshal(dst.UserTokenWithSecret)
+	// use discriminator value to speed up the lookup
+	var jsonDict map[string]interface{}
+	err = json.Unmarshal(data, &jsonDict)
+	if err != nil {
+		return fmt.Errorf("Failed to unmarshal JSON into map for the discriminator lookup.")
+	}
+
+	// check if the discriminator value is 'UserTokenWithSecret'
+	if jsonDict["type"] == "UserTokenWithSecret" {
+		// try to unmarshal JSON data into UserTokenWithSecret
+		err = json.Unmarshal(data, &dst.UserTokenWithSecret)
 		if err == nil {
-			if string(jsonUserTokenWithSecret) == "{}" { // empty struct
-				dst.UserTokenWithSecret = nil
-			} else {
-				match++
-			}
+			return nil // data stored in dst.UserTokenWithSecret, return on the first match
 		} else {
 			dst.UserTokenWithSecret = nil
+			return fmt.Errorf("Failed to unmarshal TokenWithSecret as UserTokenWithSecret: %s", err.Error())
 		}
-	} else {
-		dst.UserTokenWithSecret = nil
 	}
 
-	if match > 1 { // more than 1 match
-		// reset to nil
-		dst.UserTokenWithSecret = nil
-
-		return fmt.Errorf("Data matches more than one schema in oneOf(TokenWithSecret)")
-	} else if match == 1 {
-		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("Data failed to match schemas in oneOf(TokenWithSecret)")
+	// check if the discriminator value is 'user'
+	if jsonDict["type"] == "user" {
+		// try to unmarshal JSON data into UserTokenWithSecret
+		err = json.Unmarshal(data, &dst.UserTokenWithSecret)
+		if err == nil {
+			return nil // data stored in dst.UserTokenWithSecret, return on the first match
+		} else {
+			dst.UserTokenWithSecret = nil
+			return fmt.Errorf("Failed to unmarshal TokenWithSecret as UserTokenWithSecret: %s", err.Error())
+		}
 	}
+
+	return nil
 }
 
 // Marshal data from the first non-nil pointers in the struct to JSON

--- a/client/pkg/client/openapi/model_workflow_run_creator.go
+++ b/client/pkg/client/openapi/model_workflow_run_creator.go
@@ -35,52 +35,62 @@ func UserWorkflowRunCreatorAsWorkflowRunCreator(v *UserWorkflowRunCreator) Workf
 // Unmarshal JSON data into one of the pointers in the struct
 func (dst *WorkflowRunCreator) UnmarshalJSON(data []byte) error {
 	var err error
-	match := 0
-	// try to unmarshal data into EventWorkflowRunCreator
-	err = json.Unmarshal(data, &dst.EventWorkflowRunCreator)
-	if err == nil {
-		jsonEventWorkflowRunCreator, err := json.Marshal(dst.EventWorkflowRunCreator)
+	// use discriminator value to speed up the lookup
+	var jsonDict map[string]interface{}
+	err = json.Unmarshal(data, &jsonDict)
+	if err != nil {
+		return fmt.Errorf("Failed to unmarshal JSON into map for the discriminator lookup.")
+	}
+
+	// check if the discriminator value is 'EventWorkflowRunCreator'
+	if jsonDict["type"] == "EventWorkflowRunCreator" {
+		// try to unmarshal JSON data into EventWorkflowRunCreator
+		err = json.Unmarshal(data, &dst.EventWorkflowRunCreator)
 		if err == nil {
-			if string(jsonEventWorkflowRunCreator) == "{}" { // empty struct
-				dst.EventWorkflowRunCreator = nil
-			} else {
-				match++
-			}
+			return nil // data stored in dst.EventWorkflowRunCreator, return on the first match
 		} else {
 			dst.EventWorkflowRunCreator = nil
+			return fmt.Errorf("Failed to unmarshal WorkflowRunCreator as EventWorkflowRunCreator: %s", err.Error())
 		}
-	} else {
-		dst.EventWorkflowRunCreator = nil
 	}
 
-	// try to unmarshal data into UserWorkflowRunCreator
-	err = json.Unmarshal(data, &dst.UserWorkflowRunCreator)
-	if err == nil {
-		jsonUserWorkflowRunCreator, err := json.Marshal(dst.UserWorkflowRunCreator)
+	// check if the discriminator value is 'UserWorkflowRunCreator'
+	if jsonDict["type"] == "UserWorkflowRunCreator" {
+		// try to unmarshal JSON data into UserWorkflowRunCreator
+		err = json.Unmarshal(data, &dst.UserWorkflowRunCreator)
 		if err == nil {
-			if string(jsonUserWorkflowRunCreator) == "{}" { // empty struct
-				dst.UserWorkflowRunCreator = nil
-			} else {
-				match++
-			}
+			return nil // data stored in dst.UserWorkflowRunCreator, return on the first match
 		} else {
 			dst.UserWorkflowRunCreator = nil
+			return fmt.Errorf("Failed to unmarshal WorkflowRunCreator as UserWorkflowRunCreator: %s", err.Error())
 		}
-	} else {
-		dst.UserWorkflowRunCreator = nil
 	}
 
-	if match > 1 { // more than 1 match
-		// reset to nil
-		dst.EventWorkflowRunCreator = nil
-		dst.UserWorkflowRunCreator = nil
-
-		return fmt.Errorf("Data matches more than one schema in oneOf(WorkflowRunCreator)")
-	} else if match == 1 {
-		return nil // exactly one match
-	} else { // no match
-		return fmt.Errorf("Data failed to match schemas in oneOf(WorkflowRunCreator)")
+	// check if the discriminator value is 'event'
+	if jsonDict["type"] == "event" {
+		// try to unmarshal JSON data into EventWorkflowRunCreator
+		err = json.Unmarshal(data, &dst.EventWorkflowRunCreator)
+		if err == nil {
+			return nil // data stored in dst.EventWorkflowRunCreator, return on the first match
+		} else {
+			dst.EventWorkflowRunCreator = nil
+			return fmt.Errorf("Failed to unmarshal WorkflowRunCreator as EventWorkflowRunCreator: %s", err.Error())
+		}
 	}
+
+	// check if the discriminator value is 'user'
+	if jsonDict["type"] == "user" {
+		// try to unmarshal JSON data into UserWorkflowRunCreator
+		err = json.Unmarshal(data, &dst.UserWorkflowRunCreator)
+		if err == nil {
+			return nil // data stored in dst.UserWorkflowRunCreator, return on the first match
+		} else {
+			dst.UserWorkflowRunCreator = nil
+			return fmt.Errorf("Failed to unmarshal WorkflowRunCreator as UserWorkflowRunCreator: %s", err.Error())
+		}
+	}
+
+	return nil
 }
 
 // Marshal data from the first non-nil pointers in the struct to JSON


### PR DESCRIPTION
### Fixed
* Use `--additional-properties useOneOfDiscriminatorLookup=true` for improved `oneOf` handling.