### PR TITLE
Remove use of deprecated ioutil

### DIFF
--- a/models/pkg/workflow/asset/asset.go
+++ b/models/pkg/workflow/asset/asset.go
@@ -2,7 +2,6 @@ package asset
 
 import (
 	"io"
-	"io/ioutil"
 )
 
 func Asset(name string) (io.ReadCloser, error) {
@@ -16,7 +15,7 @@ func AssetString(name string) (string, error) {
 	}
 	defer asset.Close()
 
-	b, err := ioutil.ReadAll(asset)
+	b, err := io.ReadAll(asset)
 	if err != nil {
 		return "", err
 	}

--- a/models/pkg/workflow/types/v1/decoder_test.go
+++ b/models/pkg/workflow/types/v1/decoder_test.go
@@ -2,7 +2,6 @@ package v1
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -102,7 +101,7 @@ func TestYAMLDecoder(t *testing.T) {
 		basename := filepath.Base(file)
 
 		t.Run(basename, func(t *testing.T) {
-			b, err := ioutil.ReadFile(file)
+			b, err := os.ReadFile(file)
 			require.NoError(t, err)
 
 			wd, err := yd.Decode(ctx, b)

--- a/models/pkg/workflow/types/v1/tenantmapping_test.go
+++ b/models/pkg/workflow/types/v1/tenantmapping_test.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/url"
 	"testing"
 
@@ -42,6 +42,6 @@ func TestTenantEngineMapping(t *testing.T) {
 	require.Equal(t, tu.String(), manifest.Tenant.Spec.WorkflowExecutionSink.API.URL)
 	require.Equal(t, "test-token-secret", manifest.Tenant.Spec.WorkflowExecutionSink.API.TokenFrom.SecretKeyRef.LocalObjectReference.Name)
 
-	require.NoError(t, json.NewEncoder(ioutil.Discard).Encode(manifest.Namespace))
-	require.NoError(t, json.NewEncoder(ioutil.Discard).Encode(manifest.Tenant))
+	require.NoError(t, json.NewEncoder(io.Discard).Encode(manifest.Namespace))
+	require.NoError(t, json.NewEncoder(io.Discard).Encode(manifest.Tenant))
 }

--- a/models/pkg/workflow/types/v1/types.go
+++ b/models/pkg/workflow/types/v1/types.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"time"
 
 	"github.com/puppetlabs/leg/stringutil"
@@ -338,7 +338,7 @@ func (c *ContainerMixin) LoadInputFile(ctx context.Context, im input.FileManager
 		return err
 	}
 
-	content, err := ioutil.ReadAll(inputFileReader)
+	content, err := io.ReadAll(inputFileReader)
 	if err != nil {
 		return err
 	}

--- a/models/pkg/workflow/types/v1/validate_test.go
+++ b/models/pkg/workflow/types/v1/validate_test.go
@@ -1,7 +1,7 @@
 package v1_test
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -17,7 +17,7 @@ func TestFixtureValidation(t *testing.T) {
 
 	for _, file := range fs {
 		t.Run(filepath.Base(file), func(t *testing.T) {
-			b, err := ioutil.ReadFile(file)
+			b, err := os.ReadFile(file)
 			require.NoError(t, err)
 
 			err = v1.ValidateYAML(string(b))
@@ -104,7 +104,7 @@ func TestFixtureValidationForTriggers(t *testing.T) {
 	}
 	for _, test := range tcs {
 		t.Run(test.Name, func(t *testing.T) {
-			b, err := ioutil.ReadFile(test.File)
+			b, err := os.ReadFile(test.File)
 			require.NoError(t, err)
 
 			err = v1.ValidateYAML(string(b))

--- a/models/pkg/workflow/types/v1/webhooktriggermapping_test.go
+++ b/models/pkg/workflow/types/v1/webhooktriggermapping_test.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/puppetlabs/relay-core/pkg/expr/serialize"
@@ -48,5 +48,5 @@ func TestWebhookTriggerMapping(t *testing.T) {
 	require.Len(t, manifest.WebhookTrigger.Spec.Spec, 1)
 	require.Len(t, manifest.WebhookTrigger.Spec.Env, 2)
 
-	require.NoError(t, json.NewEncoder(ioutil.Discard).Encode(manifest.WebhookTrigger))
+	require.NoError(t, json.NewEncoder(io.Discard).Encode(manifest.WebhookTrigger))
 }

--- a/models/pkg/workflow/types/v1/workflowmapper_test.go
+++ b/models/pkg/workflow/types/v1/workflowmapper_test.go
@@ -3,7 +3,7 @@ package v1
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -60,6 +60,6 @@ func TestWorkflowMapper(t *testing.T) {
 	require.Equal(t, "hi", mapping.Workflow.Spec.Parameters[0].Name)
 	require.Equal(t, 5, mapping.Workflow.Spec.Parameters[0].Value.Value().(int))
 
-	require.NoError(t, json.NewEncoder(ioutil.Discard).Encode(mapping.Namespace))
-	require.NoError(t, json.NewEncoder(ioutil.Discard).Encode(mapping.Workflow))
+	require.NoError(t, json.NewEncoder(io.Discard).Encode(mapping.Namespace))
+	require.NoError(t, json.NewEncoder(io.Discard).Encode(mapping.Workflow))
 }

--- a/models/pkg/workflow/types/v1/workflowrunmapping_test.go
+++ b/models/pkg/workflow/types/v1/workflowrunmapping_test.go
@@ -2,7 +2,7 @@ package v1
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -24,6 +24,6 @@ func TestWorkflowRunEngineMapping(t *testing.T) {
 	require.Equal(t, "valid-workflow", manifest.Namespace.GetName())
 	require.Equal(t, "valid-workflow-run-name", manifest.WorkflowRun.GetName())
 
-	require.NoError(t, json.NewEncoder(ioutil.Discard).Encode(manifest.Namespace))
-	require.NoError(t, json.NewEncoder(ioutil.Discard).Encode(manifest.WorkflowRun))
+	require.NoError(t, json.NewEncoder(io.Discard).Encode(manifest.Namespace))
+	require.NoError(t, json.NewEncoder(io.Discard).Encode(manifest.WorkflowRun))
 }


### PR DESCRIPTION
Remove (direct) use of deprecated `ioutil` in favor of the default `io` and `os` standard libraries.

This does not include `generate_assets.go`, which is generated using third-party [`vfsgen`](https://github.com/shurcooL/vfsgen), which has not been updated since Aug 23, 2020.